### PR TITLE
Prove measurableSet_bot_iff_empty_or_univ

### DIFF
--- a/src/Bluebell/ProbabilityTheory/IndepProduct.lean
+++ b/src/Bluebell/ProbabilityTheory/IndepProduct.lean
@@ -36,9 +36,8 @@ theorem sum_comm (m₁ m₂ : MeasurableSpace Ω) :
 
 /-- Characterization of measurability at the bottom measurable space (stated API). -/
 theorem measurableSet_bot_iff_empty_or_univ {s : Set Ω} :
-    MeasurableSet[⊥] s ↔ s = ∅ ∨ s = Set.univ := by
-  -- In the bottom σ-algebra, only `∅` and `univ` are measurable.
-  sorry
+    MeasurableSet[⊥] s ↔ s = ∅ ∨ s = Set.univ :=
+  measurableSet_bot_iff
 
 /-- Left unit: bottom sums to the other measurable space (API). -/
 theorem bot_sum (m : MeasurableSpace Ω) :


### PR DESCRIPTION
## Summary
- Prove `MeasurableSpace.measurableSet_bot_iff_empty_or_univ` using mathlib's existing `measurableSet_bot_iff` lemma

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)