### PR TITLE
Prove bot_sum and sum_bot

### DIFF
--- a/src/Bluebell/ProbabilityTheory/IndepProduct.lean
+++ b/src/Bluebell/ProbabilityTheory/IndepProduct.lean
@@ -43,16 +43,30 @@ theorem measurableSet_bot_iff_empty_or_univ {s : Set Ω} :
 /-- Left unit: bottom sums to the other measurable space (API). -/
 theorem bot_sum (m : MeasurableSpace Ω) :
     MeasurableSpace.sum (⊥ : MeasurableSpace Ω) m = m := by
-  -- Follows since `MeasurableSet[⊥] = ∅`.
-  simp [MeasurableSpace.sum]
-  sorry
+  simp only [MeasurableSpace.sum]
+  have h : (MeasurableSet[⊥] ∪ MeasurableSet[m] : Set (Set Ω)) = MeasurableSet[m] := by
+    ext s
+    simp only [Set.mem_union]
+    constructor
+    · intro hs
+      rcases hs with hbot | hm
+      · have : MeasurableSet[⊥] s := hbot
+        rw [measurableSet_bot_iff] at this
+        rcases this with rfl | rfl
+        · exact @MeasurableSet.empty Ω m
+        · exact @MeasurableSet.univ Ω m
+      · exact hm
+    · intro hm
+      right
+      exact hm
+  rw [h]
+  exact @generateFrom_measurableSet Ω m
 
 /-- Right unit: summing with bottom yields the same space (API). -/
 theorem sum_bot (m : MeasurableSpace Ω) :
     MeasurableSpace.sum m (⊥ : MeasurableSpace Ω) = m := by
-  -- Follows since `MeasurableSet[⊥] = ∅`.
-  simp [MeasurableSpace.sum, Set.union_comm]
-  sorry
+  rw [sum_comm]
+  exact bot_sum m
 
 end MeasurableSpace
 


### PR DESCRIPTION
## Summary
- Prove `MeasurableSpace.bot_sum`: `(⊥ : MeasurableSpace).sum m = m`
- Prove `MeasurableSpace.sum_bot`: `m.sum ⊥ = m` (via `bot_sum` and `sum_comm`)

The key insight is that `MeasurableSet[⊥] = {∅, univ}` (from mathlib's `measurableSet_bot_iff`), and these are always measurable in any space, so the union simplifies to `MeasurableSet[m]`.

Closes #153
Closes #161

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)