### PR TITLE
Prove IsTotal assumption is false for IndexedPSpPm

### DIFF
--- a/src/Bluebell/Algebra/CMRA.lean
+++ b/src/Bluebell/Algebra/CMRA.lean
@@ -151,4 +151,22 @@ noncomputable instance cmraFun {ι : Type*} {β : ι → Type*} [∀ i, CMRA (β
       by intro i; exact (F i).2.2.2.1,
       by intro i; exact (F i).2.2.2.2⟩
 
+/-- The predicated product CMRA `ProdRel` is never total because `pcore` is constantly `none`. -/
+theorem ProdRel.not_isTotal [CompatibleRel (α := α) (β := β) Φ]
+    [Nonempty (ProdRel (α := α) (β := β) Φ)] :
+    ¬ CMRA.IsTotal (ProdRel (α := α) (β := β) Φ) := by
+  intro ⟨h⟩
+  obtain ⟨x⟩ : Nonempty (ProdRel Φ) := inferInstance
+  have ⟨_, hcx⟩ := h x
+  exact Option.noConfusion hcx
+
+/-- The function-space CMRA `cmraFun` is never total because `pcore` is constantly `none`. -/
+theorem cmraFun.not_isTotal {ι : Type*} {β : ι → Type*} [∀ i, CMRA (β i)]
+    [Nonempty ((i : ι) → β i)] :
+    ¬ CMRA.IsTotal ((i : ι) → β i) := by
+  intro ⟨h⟩
+  obtain ⟨f⟩ : Nonempty ((i : ι) → β i) := inferInstance
+  have ⟨_, hcf⟩ := h f
+  exact Option.noConfusion hcf
+
 end Bluebell

--- a/src/Bluebell/Algebra/PSpPm.lean
+++ b/src/Bluebell/Algebra/PSpPm.lean
@@ -102,6 +102,16 @@ def liftProb (μ : I → ProbabilityTheory.ProbabilitySpace (α → V)) : Indexe
 noncomputable instance [Nonempty V] : CMRA (IndexedPSpPm I α V F) :=
   inferInstanceAs (CMRA (I → PSpPm α V F))
 
+/-- `IndexedPSpPm` is never total because it uses `cmraFun` which has `pcore _ := none`.
+This means the `CMRA.IsTotal (IndexedPSpPm I α V F)` assumption used in `wp_frame`
+and `sep_assoc` is false and these theorems have unsatisfiable hypotheses. -/
+theorem not_isTotal [Nonempty V] [h : Nonempty (IndexedPSpPm I α V F)] :
+    ¬ Iris.CMRA.IsTotal (IndexedPSpPm I α V F) := by
+  intro ⟨htotal⟩
+  obtain ⟨f⟩ := h
+  have ⟨_, hcf⟩ := htotal f
+  exact Option.noConfusion hcf
+
 end IndexedPSpPm
 
 end Bluebell


### PR DESCRIPTION
## Summary

Add proofs showing that the `CMRA.IsTotal (IndexedPSpPm I α V F)` assumption used in `wp_frame` and `sep_assoc` is [**provably false**](https://github.com/Verified-zkEVM/iris-lean/blob/fix/false-istotal-assumption/src/Bluebell/Algebra/PSpPm.lean#L108-L113).

## Changes

- `ProdRel.not_isTotal`: Shows `ProdRel` CMRA is never total
- `cmraFun.not_isTotal`: Shows function-space CMRA is never total
- `IndexedPSpPm.not_isTotal`: Shows the main model type is never total

## Root cause

Both `cmraProdRel` and `cmraFun` define `pcore _ := none`, making the `IsTotal` requirement (which needs `pcore x = some cx` for all `x`) impossible to satisfy.

## Related

- #248
- Solution described in #243: switch `PSpPm` to use `PermissionRat` instead of `Permission α F`

🤖 Generated with [Claude Code](https://claude.com/claude-code)