### PR TITLE
Add Bluebell to default build targets

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "iris"
 srcDir = "./src/"
-defaultTargets = ["Iris", "IrisTest"]
+defaultTargets = ["Iris", "Bluebell", "IrisTest"]
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
## Summary

Add `Bluebell` to the default build targets in `lakefile.toml` so that `lake build` builds all three libraries.

## Changes

- `defaultTargets = ["Iris", "IrisTest"]` → `defaultTargets = ["Iris", "Bluebell", "IrisTest"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)