### PR TITLE
Prove IndependentProduct.symm and indepProduct_isSome_comm (#158, #159)

### DIFF
--- a/src/Bluebell/ProbabilityTheory/IndepProduct.lean
+++ b/src/Bluebell/ProbabilityTheory/IndepProduct.lean
@@ -145,9 +145,14 @@ variable {m₁ m₂ : MeasurableSpace Ω} {μ₁ : Measure[m₁] Ω} {μ₂ : Me
 /-- Symmetry: swap factors of an independent product (API). -/
 def Measure.IndependentProduct.symm
     (w : Measure.IndependentProduct μ₁ μ₂) :
-    Measure.IndependentProduct μ₂ μ₁ := by
-  -- Build the symmetric witness using `MeasurableSpace.sum_comm` and `mul_comm`.
-  sorry
+    Measure.IndependentProduct μ₂ μ₁ where
+  μ := MeasurableSpace.sum_comm m₂ m₁ ▸ w.μ
+  inter_eq_prod := by
+    intro X Y hX hY
+    have heq : MeasurableSpace.sum m₂ m₁ = MeasurableSpace.sum m₁ m₂ := MeasurableSpace.sum_comm m₂ m₁
+    have key : (heq ▸ w.μ) (X ∩ Y) = w.μ (X ∩ Y) := by
+      revert heq; generalize MeasurableSpace.sum m₂ m₁ = m'; intro heq; subst heq; rfl
+    rw [key, Set.inter_comm, w.inter_eq_prod hY hX, mul_comm]
 
 /-- The independent product of two measures is unique, if it exists -/
 instance {μ₁ : Measure[m₁] Ω} {μ₂ : Measure[m₂] Ω} : Subsingleton (Measure.IndependentProduct μ₁ μ₂) := by
@@ -192,8 +197,13 @@ theorem indepProduct_assoc (m₁ m₂ m₃ : MeasureSpace Ω) :
 /-- Corollary: existence of the independent product is symmetric. -/
 theorem indepProduct_isSome_comm (m₁ m₂ : MeasureSpace Ω) :
     (indepProduct (Ω := Ω) m₁ m₂).isSome = (indepProduct (Ω := Ω) m₂ m₁).isSome := by
-  -- Immediate from commutativity.
-  sorry
+  simp only [indepProduct]
+  have h : Nonempty (Measure.IndependentProduct m₁.volume m₂.volume) ↔
+           Nonempty (Measure.IndependentProduct m₂.volume m₁.volume) :=
+    ⟨fun ⟨w⟩ => ⟨w.symm⟩, fun ⟨w⟩ => ⟨w.symm⟩⟩
+  by_cases h₁ : Nonempty (Measure.IndependentProduct m₁.volume m₂.volume)
+  · simp [h₁, h.mp h₁]
+  · simp [h₁, mt h.mpr h₁]
 
 end MeasureSpace
 end MeasureTheory


### PR DESCRIPTION
## Summary
- Prove `Measure.IndependentProduct.symm`: symmetry of independent product witnesses using `MeasurableSpace.sum_comm`
- Prove `indepProduct_isSome_comm`: existence of independent product is symmetric (corollary of `symm`)

Closes #158, closes #159

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)