### PR TITLE
Prove SPMF.IsCoupling.symm

### DIFF
--- a/src/Bluebell/ProbabilityTheory/Coupling.lean
+++ b/src/Bluebell/ProbabilityTheory/Coupling.lean
@@ -237,7 +237,7 @@ theorem IsCoupling.map
 theorem IsCoupling.symm {c : SPMF (α × β)} {p : SPMF α} {q : SPMF β}
     (hc : IsCoupling c p q) :
     IsCoupling (Prod.swap.{u, u} <$> c) q p := by
-  constructor <;> sorry
+  constructor <;> simp [hc.map_fst, hc.map_snd]
 
 /-- Monadic bind rule for relational lifting (PRHL bind). -/
 theorem Lift.bind {p : SPMF α} {q : SPMF β} {R : Set (α × β)}


### PR DESCRIPTION
## Summary
- Proves `SPMF.IsCoupling.symm` (closes #150): swapping a coupling via `Prod.swap` swaps the marginals
- One-line proof using `simp` with the coupling's `map_fst`/`map_snd` hypotheses, which leverages functor composition laws (`Prod.fst ∘ Prod.swap = Prod.snd` and vice versa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)