### PR TITLE
prove C_conseq: monotonicity of jointCondition modality

### DIFF
--- a/src/Bluebell/Logic/JointCondition.lean
+++ b/src/Bluebell/Logic/JointCondition.lean
@@ -100,7 +100,7 @@ variable {β : Type*} [MeasurableSpace β] {μ : PMF β}
 theorem C_conseq (h : ∀ v, K₁ v ⊢ K₂ v) : 𝑪_ μ K₁ ⊢ 𝑪_ μ K₂ := by
   intro a ha
   obtain ⟨P, p, hc, κ, hinc, hμ, hK⟩ := ha
-  exact ⟨P, p, hc, κ, hinc, hμ, fun v hv => h v _ (hK v hv)⟩
+  exact ⟨P, p, hc, κ, hinc, hμ, fun v hv ↦ h v _ (hK v hv)⟩
 
 theorem C_frame {P : HyperAssertion (IndexedPSpPmRat I α V)} :
     P ∗ 𝑪_ μ K ⊢ 𝑪_ μ (fun v => sep P (K v)) := by

--- a/src/Bluebell/Logic/JointCondition.lean
+++ b/src/Bluebell/Logic/JointCondition.lean
@@ -98,7 +98,9 @@ variable {β : Type*} [MeasurableSpace β] {μ : PMF β}
   [MeasurableSpace V]
 
 theorem C_conseq (h : ∀ v, K₁ v ⊢ K₂ v) : 𝑪_ μ K₁ ⊢ 𝑪_ μ K₂ := by
-  sorry
+  intro a ha
+  obtain ⟨P, p, hc, κ, hinc, hμ, hK⟩ := ha
+  exact ⟨P, p, hc, κ, hinc, hμ, fun v hv => h v _ (hK v hv)⟩
 
 theorem C_frame {P : HyperAssertion (IndexedPSpPmRat I α V)} :
     P ∗ 𝑪_ μ K ⊢ 𝑪_ μ (fun v => sep P (K v)) := by


### PR DESCRIPTION
## Summary
- Proves `C_conseq` (issue #183): the consequence/monotonicity rule for the `𝑪_` modality
- Reuses the same existential witnesses (`P`, `p`, `κ`) and applies the entailment hypothesis to convert `K₁ v` to `K₂ v` for each `v` in the PMF support

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)