### PR TITLE
ci: rename style_guide_path to additional_instructions_path

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -27,6 +27,6 @@ jobs:
           github_repository: ${{ github.repository }}
           pr_number: ${{ github.event.pull_request.number }}
           # Optional:
-          style_guide_path: 'CONTRIBUTING.md'
+          additional_instructions_path: 'CONTRIBUTING.md'
           validate_title: 'true'
           # upstream_path: 'ToMathlib/'


### PR DESCRIPTION
Tracks the upstream rename in alexanderlhicks/lean-summary-workflow. The input semantics are unchanged for this fork — the new name better reflects that the file passed in can be any deployment-supplied instructions, not just a style guide.

Merge ordering: the upstream lean-summary-workflow PR renaming the input must land before this PR.

## Description
Briefly describe your changes, and link any issues if appropriate.

Fixes # (issue number)

## Checklist
* [ ] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have updated `PORTING.md` as appropriate
* [ ] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
